### PR TITLE
Remove `private` field and those unused

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "description": "Chico UI themes",
   "repository": "<%= author.html_url %>/<%= slugifiedName %>",
-  "private": true,
   "authors": [
     {
       "name": "<%= author.name %>",


### PR DESCRIPTION
This will only prevent the package to be published *anywhere*. If we want to specify a private registry we should include a `.npmrc` —but since this is currently public, I don't this this is a good idea.

Also y removed `keywords` and `dependencies` keys since they are not being used.

*Should I open an issue to request this repo to be private?*